### PR TITLE
Patch to use IMAGE_MAGICK_VERSION config variable from Heroku for version

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -16,9 +16,18 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
-IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.0.8-28}"
+if [ -d $ENV_DIR ]; then
+  ENV_FILE="$ENV_DIR/IMAGE_MAGICK_VERSION"
+  if [ -f $ENV_FILE ]; then
+    IMAGE_MAGICK_VERSION="`cat $ENV_FILE`"
+  else
+    IMAGE_MAGICK_VERSION="7.0.8-28"
+  fi
+else
+  IMAGE_MAGICK_VERSION="7.0.8-28"
+fi
 # Use Imagemagick binary from S3
-CACHE_FILE="https://s3.amazonaws.com/imagemagick/ImageMagick-7.0.8-28.tar.gz"
+CACHE_FILE="https://s3.amazonaws.com/imagemagick/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,8 @@ mkdir -p $VENDOR_DIR
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 mkdir -p $INSTALL_DIR
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.0.8-28}"
-CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
+# Use Imagemagick binary from S3
+CACHE_FILE="https://s3.amazonaws.com/imagemagick/ImageMagick-7.0.8-28.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick

--- a/bin/compile
+++ b/bin/compile
@@ -27,7 +27,7 @@ else
   IMAGE_MAGICK_VERSION="7.0.8-28"
 fi
 # Use Imagemagick binary from S3
-CACHE_FILE="https://s3.amazonaws.com/imagemagick/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
+CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick


### PR DESCRIPTION
- Inspiration (copied) from ello/heroku-buildpack-imagemagick#16 to use `IMAGE_MAGICK_VERSION` config varilable in Heroku to define ImageMagick version to use. 
